### PR TITLE
fix redirect issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ application {
 }
 
 group = "de.uzl.itcr"
-version = "1.0.0"
+version = "1.0.1"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {

--- a/src/main/kotlin/de/uzl/itcr/termicron/StaticHelpers.kt
+++ b/src/main/kotlin/de/uzl/itcr/termicron/StaticHelpers.kt
@@ -36,6 +36,7 @@ class StaticHelpers {
         fun httpClient(initializer: (HttpClient.Builder.() -> Unit)? = null): HttpClient =
             HttpClient.newBuilder().apply {
                 version(HttpClient.Version.HTTP_1_1)
+                followRedirects(HttpClient.Redirect.ALWAYS)
                 initializer?.invoke(this)
             }
                 .connectTimeout(Duration.ofSeconds(20))


### PR DESCRIPTION
The default HTTP client instance did not follow redirects. This makes sure that the client always follows redirects, e.g. from HTTP to HTTPS, or from Simplififier